### PR TITLE
Allow any fluid version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Lint/syntax check for TYPO3.Fluid template files",
 	"license": ["MIT"],
 	"require": {
-		"typo3fluid/fluid": "^1.0"
+		"typo3/cms-fluid": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"description": "Lint/syntax check for TYPO3.Fluid template files",
 	"license": ["MIT"],
 	"require": {
-		"typo3/cms-fluid": "*"
+		"typo3fluid/fluid": "*"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "*",


### PR DESCRIPTION
The linter requires `typo3fluid/fluid` ^1.0 which is not compatible with TYPO3 9.5 or later.
I found a fork that allows any fluid version. Not sure if that works out for the linter.

At least version ^2.0 should be allowed as well.